### PR TITLE
Use a TTL index instead of a Crone job 

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -5,7 +5,4 @@ PORT=3000
 MONGO_URL=mongodb://localhost:27017/test
 
 # A life time of the instance before it will be removed
-INSTANCE_EXPIRATION_TIME_MS=60000
-
-# A cron schedule for the removing outdated instances periodic job
-INSTANCE_EXPIRATION_CHECK_INTERVAL_CRON=*/30 * * * * *
+INSTANCE_EXPIRATION_TIME_SEC=60

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "start": "nodemon"
   },
   "dependencies": {
-    "cron": "^1.8.2",
     "dotenv": "^10.0.0",
     "http-status-codes": "^2.1.4",
     "koa": "^2.13.1",
@@ -22,7 +21,6 @@
     "mongoose": "^5.13.3"
   },
   "devDependencies": {
-    "@types/cron": "^1.7.3",
     "@types/http-status-codes": "^1.2.0",
     "@types/koa": "^2.13.4",
     "@types/koa-bodyparser": "^4.3.2",

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,7 +2,6 @@ import * as Koa from 'koa';
 import * as bodyParser from 'koa-bodyparser';
 import { StatusCodes } from 'http-status-codes';
 
-import { cron } from './cron';
 import instancesController from './instances/instances.controller';
 import MongoDB from './database';
 
@@ -24,8 +23,6 @@ app.use(bodyParser());
 
 app.use(instancesController.routes());
 app.use(instancesController.allowedMethods());
-
-cron.start();
 
 MongoDB.init();
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,16 +6,14 @@ dotenv.config({ path: '.env' });
 export interface Config {
   port: number;
   mongoUrl: string;
-  instanceExpirationTimeMs: number;
-  instanceExpirationCheckIntervalCron: string;
+  instanceExpirationTimeSec: number;
 }
 
 
 const config: Config = {
   port: Number(process.env.PORT || 3000),
   mongoUrl: process.env.MONGO_URL || 'mongodb://localhost:27017/test',
-  instanceExpirationTimeMs: Number(process.env.INSTANCE_EXPIRATION_TIME_MS || 60000),
-  instanceExpirationCheckIntervalCron: process.env.INSTANCE_EXPIRATION_CHECK_INTERVAL_CRON || '*/30 * * * * *'
+  instanceExpirationTimeSec: Number(process.env.INSTANCE_EXPIRATION_TIME_SEC || 60),
 };
 
 export { config };

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -1,9 +1,0 @@
-import { CronJob } from 'cron';
-import { config } from './config';
-import { instancesService } from './instances/instances.service';
-
-const cron = new CronJob(config.instanceExpirationCheckIntervalCron, async () => {
-  await instancesService.removeExpiredInstances(config.instanceExpirationTimeMs)
-});
-
-export { cron };

--- a/src/database/models/instance.model.ts
+++ b/src/database/models/instance.model.ts
@@ -1,4 +1,5 @@
 import { Schema, model, Document } from 'mongoose'
+import { config } from '../../config';
 
 
 export interface Instance extends Document {
@@ -6,6 +7,7 @@ export interface Instance extends Document {
   group: string;
   createdAt: number;
   updatedAt: number;
+  lastHeartBeat: Date;
   meta: unknown;
 }
 
@@ -16,6 +18,7 @@ const instanceSchema = new Schema(
     group: { type: String, required: true },
     createdAt: { type: Number },
     updatedAt: { type: Number },
+    lastHeartBeat: { type: Date, default: Date.now },
     meta: Object,
   },
   {
@@ -23,5 +26,6 @@ const instanceSchema = new Schema(
   }
 )
   .index({ group: 1, id: 1 }, { unique: true })
+  .index({ lastHeartBeat: 1 }, { expireAfterSeconds: config.instanceExpirationTimeSec })
 
 export default model<Instance>('Instance', instanceSchema)

--- a/src/instances/instances.service.ts
+++ b/src/instances/instances.service.ts
@@ -4,7 +4,7 @@ import { CreateInstanceDto, IdentifyInstanceDto, UpdateInstanceDto, GroupDto } f
 
 
 class InstancesService {
-  private readonly fieldsToHideSelector = { _id: 0, __v: 0 };
+  private readonly fieldsToHideSelector = { _id: 0, __v: 0, lastHeartBeat: 0 };
 
   async create (createInstanceDto: CreateInstanceDto) {
     await InstanceModel.create(createInstanceDto)
@@ -48,16 +48,6 @@ class InstancesService {
     const result = await InstanceModel.deleteOne(query);
 
     return Boolean(result.deletedCount)
-  }
-
-  async removeExpiredInstances (instanceExpirationTimeInMs: number) {
-    console.log('InstancesService::removeExpiredInstances -- periodic job started');
-    const dateNow = Date.now();
-    const theEdge = dateNow - instanceExpirationTimeInMs;
-    const query = { updatedAt: { $lte: theEdge } };
-    const { deletedCount } = await InstanceModel.deleteMany(query);
-    console.log(`InstancesService::removeExpiredInstances -- amount of deleted instances: ${deletedCount}`);
-    console.log('InstancesService::removeExpiredInstances -- periodic job finished');
   }
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,10 +1,9 @@
 import app from './app'
 import { config } from './config';
-import { cron } from './cron';
 import MongoDB from './database';
 
+
 MongoDB.init();
-cron.start();
 
 app.listen(config.port, () => {
   console.log(`Server running on port ${config.port}`);


### PR DESCRIPTION
* [The background task that removes expired documents runs every 60 seconds.](https://docs.mongodb.com/manual/core/index-ttl/)
* If we are OK with that period and weak removing time guarantees - a TTL index can be used instead of a Cron job